### PR TITLE
Fix DEX pool route middleware reference

### DIFF
--- a/backend/src/api/routes/dexRoutes.ts
+++ b/backend/src/api/routes/dexRoutes.ts
@@ -10,6 +10,6 @@ router.get('/api/dex/pool/:coinId', dexController.getPoolInfo);
 router.get('/api/dex/price-history/:coinId', dexController.getPriceHistory);
 router.get('/api/dex/market-cap/:coinId', dexController.getMarketCap);
 router.post('/api/dex/price-impact/:coinId', dexController.calculatePriceImpact);
-router.post('/api/dex/create-pool/:coinId', authMiddleware.authenticate, dexController.createDexPool);
+router.post('/api/dex/create-pool/:coinId', authMiddleware, dexController.createDexPool);
 
 export default router;


### PR DESCRIPTION
## Summary
- fix the DEX create-pool route to use the auth middleware function instead of an undefined authenticate property

## Testing
- pnpm run dev *(fails: ts-node-dev not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e28578bb0083319ea57db9b5b4167d