### PR TITLE
Fix DEX create pool route handler wiring

### DIFF
--- a/backend/src/api/routes/dexRoutes.ts
+++ b/backend/src/api/routes/dexRoutes.ts
@@ -1,6 +1,6 @@
 import express from 'express';
-import { dexController } from '../controllers';
-import { authMiddleware } from '../middleware';
+import dexController from '../controllers/dexController';
+import authMiddleware from '../middleware/authMiddleware';
 
 const router = express.Router();
 
@@ -10,6 +10,10 @@ router.get('/api/dex/pool/:coinId', dexController.getPoolInfo);
 router.get('/api/dex/price-history/:coinId', dexController.getPriceHistory);
 router.get('/api/dex/market-cap/:coinId', dexController.getMarketCap);
 router.post('/api/dex/price-impact/:coinId', dexController.calculatePriceImpact);
-router.post('/api/dex/create-pool/:coinId', authMiddleware, dexController.createDexPool);
+router.post(
+  '/api/dex/create-pool/:coinId',
+  authMiddleware,
+  (req, res) => dexController.createDexPool(req, res)
+);
 
 export default router;


### PR DESCRIPTION
## Summary
- update the DEX route to import the controller and auth middleware directly
- wrap the create pool handler in an inline function so Express receives a defined callback

## Testing
- pnpm run dev *(fails: ts-node-dev not found in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a93c1d448331b6fb1b226c12dfa4