### PR TITLE
Fix backend build by adding Socket.IO type declarations

### DIFF
--- a/backend/src/types/socket.io.d.ts
+++ b/backend/src/types/socket.io.d.ts
@@ -1,0 +1,28 @@
+import type { Server as HttpServer } from 'http'
+import type { EventEmitter } from 'events'
+
+declare module 'socket.io' {
+  interface ServerOptions {
+    cors?: {
+      origin?: string | string[];
+      methods?: string[];
+    };
+    [key: string]: unknown;
+  }
+
+  export interface Socket extends EventEmitter {
+    id: string
+    join(room: string): void
+    leave(room: string): void
+    on(event: 'disconnect', listener: () => void): this
+    on(event: string, listener: (...args: any[]) => void): this
+  }
+
+  export class Server extends EventEmitter {
+    constructor(httpServer: HttpServer, options?: ServerOptions)
+    emit(event: string, ...args: any[]): boolean
+    to(room: string): Server
+    on(event: 'connection', listener: (socket: Socket) => void): this
+    on(event: string, listener: (...args: any[]) => void): this
+  }
+}


### PR DESCRIPTION
## Summary
- add lightweight Socket.IO module type declarations to satisfy the backend TypeScript compiler

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e3f486b4188331953a9fad45895372