### PR TITLE
Fix TypeScript module resolution for backend build

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "commonjs",
+    "moduleResolution": "node",
     "lib": ["ES2020"],
     "outDir": "dist",
     "rootDir": "src",


### PR DESCRIPTION
## Summary
- configure the backend TypeScript compiler to resolve modules using Node's algorithm to pick up installed socket.io types

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e4013e42dc83319cf320a76312edb2