### PR TITLE
Add socket.io type declarations for backend build

### DIFF
--- a/backend/src/types/socket.io.d.ts
+++ b/backend/src/types/socket.io.d.ts
@@ -1,28 +1,29 @@
-import type { Server as HttpServer } from 'http'
-import type { EventEmitter } from 'events'
-
 declare module 'socket.io' {
+  import type { Server as HttpServer } from 'http'
+
   interface ServerOptions {
     cors?: {
-      origin?: string | string[];
-      methods?: string[];
-    };
-    [key: string]: unknown;
+      origin?: string | string[]
+      methods?: string[]
+      credentials?: boolean
+    }
+    [key: string]: unknown
   }
 
-  export interface Socket extends EventEmitter {
+  interface Socket {
     id: string
     join(room: string): void
     leave(room: string): void
-    on(event: 'disconnect', listener: () => void): this
     on(event: string, listener: (...args: any[]) => void): this
   }
 
-  export class Server extends EventEmitter {
+  class Server {
     constructor(httpServer: HttpServer, options?: ServerOptions)
-    emit(event: string, ...args: any[]): boolean
-    to(room: string): Server
     on(event: 'connection', listener: (socket: Socket) => void): this
     on(event: string, listener: (...args: any[]) => void): this
+    emit(event: string, ...args: any[]): boolean
+    to(room: string): Server
   }
+
+  export { Server, ServerOptions, Socket }
 }


### PR DESCRIPTION
## Summary
- add an ambient socket.io module declaration so the backend TypeScript build can resolve the dependency

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e40753e184833186610ef0d4582387