### PR TITLE
Handle missing Socket.IO dependency gracefully

### DIFF
--- a/backend/src/services/notificationService.ts
+++ b/backend/src/services/notificationService.ts
@@ -1,15 +1,45 @@
 import { Server } from 'http'
-import { Server as SocketServer } from 'socket.io'
 import type { Socket } from 'socket.io'
+
+type SocketIOServer = import('socket.io').Server
 import { logger } from '../utils/logger'
 
 class NotificationService {
-  private io: SocketServer | null = null
+  private io: SocketIOServer | null = null
+  private SocketServerConstructor: typeof import('socket.io').Server | null = null
+
+  /**
+   * Safely load Socket.IO at runtime.
+   */
+  private loadSocketServer(): typeof import('socket.io').Server | null {
+    if (this.SocketServerConstructor) {
+      return this.SocketServerConstructor
+    }
+
+    try {
+      const socketIo = require('socket.io') as typeof import('socket.io')
+      this.SocketServerConstructor = socketIo.Server
+      return this.SocketServerConstructor
+    } catch (error) {
+      logger.error(
+        'Socket.IO module not found. Real-time notifications are disabled. Install "socket.io" to enable this feature.',
+        error
+      )
+      return null
+    }
+  }
 
   /**
    * Initialize Socket.IO server
    */
   initialize(server: Server) {
+    const SocketServer = this.loadSocketServer()
+
+    if (!SocketServer) {
+      logger.warn('Notification service initialization skipped because Socket.IO is unavailable.')
+      return
+    }
+
     this.io = new SocketServer(server, {
       cors: {
         origin: process.env.FRONTEND_URL || 'http://localhost:5173',


### PR DESCRIPTION
## Summary
- lazy-load the Socket.IO server in the notification service so the backend can start even when the dependency is absent
- log clear errors and warnings when Socket.IO is unavailable while keeping existing notification hooks intact

## Testing
- npm run build:backend

------
https://chatgpt.com/codex/tasks/task_e_68e40e91192c8331bd12b0c5bb82e6cf