### PR TITLE
Allow configuring backend host

### DIFF
--- a/backend/src/config/server.ts
+++ b/backend/src/config/server.ts
@@ -1,6 +1,16 @@
 // Server configuration
+const parsePort = (port?: string): number => {
+  if (!port) {
+    return 3000;
+  }
+
+  const parsedPort = Number(port);
+  return Number.isNaN(parsedPort) ? 3000 : parsedPort;
+};
+
 export const SERVER_CONFIG = {
-  port: process.env.PORT || 3000,
+  host: process.env.HOST || '0.0.0.0',
+  port: parsePort(process.env.PORT),
   env: process.env.NODE_ENV || 'development',
   corsOptions: {
     origin: process.env.CORS_ORIGIN || '*',

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,17 +1,18 @@
 import dotenv from 'dotenv';
 import { logger } from './utils/logger';
 import app from './app';
+import { SERVER_CONFIG } from './config/server';
 import { disconnectDatabase } from './config/database';
 
 // Load environment variables
 dotenv.config();
 
-// Define port
-const port = process.env.PORT || 3000;
+// Define host and port
+const { host, port } = SERVER_CONFIG;
 
 // Start server
-const server = app.listen(port, () => {
-  logger.info(`Server running on port ${port}`);
+const server = app.listen(port, host, () => {
+  logger.info(`Server running on ${host}:${port}`);
   logger.info(`Environment: ${process.env.NODE_ENV || 'development'}`);
 });
 


### PR DESCRIPTION
## Summary
- allow configuring the backend HTTP host via a HOST environment variable that defaults to 0.0.0.0
- parse the PORT value to ensure it is numeric before starting the server and log the full host:port binding

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4d5b1f9508331a7481253d0a049fe