### PR TITLE
Handle server port conflicts with automatic fallback

### DIFF
--- a/backend/src/config/server.ts
+++ b/backend/src/config/server.ts
@@ -1,16 +1,21 @@
 // Server configuration
-const parsePort = (port?: string): number => {
-  if (!port) {
-    return 3000;
+const parseNumber = (value: string | undefined, defaultValue: number): number => {
+  if (!value) {
+    return defaultValue;
   }
 
-  const parsedPort = Number(port);
-  return Number.isNaN(parsedPort) ? 3000 : parsedPort;
+  const parsed = Number(value);
+  return Number.isNaN(parsed) ? defaultValue : parsed;
+};
+
+const parsePort = (port?: string): number => {
+  return parseNumber(port, 3000);
 };
 
 export const SERVER_CONFIG = {
   host: process.env.HOST || '0.0.0.0',
   port: parsePort(process.env.PORT),
+  portFallbackAttempts: parseNumber(process.env.PORT_FALLBACK_ATTEMPTS, 5),
   env: process.env.NODE_ENV || 'development',
   corsOptions: {
     origin: process.env.CORS_ORIGIN || '*',


### PR DESCRIPTION
## Summary
- add a shared numeric parser to the server configuration and expose a configurable port fallback limit
- update the server bootstrap to retry on subsequent ports when the configured port is already in use and improve logging

## Testing
- pnpm run build


------
https://chatgpt.com/codex/tasks/task_e_68e4f6c909b483319eca974cc601869d