### PR TITLE
fix: resolve API base URL dynamically

### DIFF
--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -3,7 +3,29 @@ import { Coin, CoinDetails } from '../types'
 import { Transaction } from '../types'
 import { handleApiError, ApiError, NetworkError, TimeoutError } from './errorHandler'
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000/api'
+const resolveApiBaseUrl = () => {
+  const configuredUrl = import.meta.env.VITE_API_URL?.toString().trim()
+  if (configuredUrl) {
+    return configuredUrl
+  }
+
+  if (typeof window !== 'undefined') {
+    const { protocol, hostname, port } = window.location
+    const isLocalhost = ['localhost', '127.0.0.1', '::1'].includes(hostname)
+
+    if (isLocalhost) {
+      const devPort = import.meta.env.VITE_API_DEV_PORT || '3000'
+      return `${protocol}//${hostname}:${devPort}/api`
+    }
+
+    const portSegment = port ? `:${port}` : ''
+    return `${protocol}//${hostname}${portSegment}/api`
+  }
+
+  return 'http://localhost:3000/api'
+}
+
+const API_URL = resolveApiBaseUrl()
 
 // Create axios instance with base configuration
 const api = axios.create({


### PR DESCRIPTION
## Summary
- resolve the frontend API base URL dynamically so deployments outside localhost stop targeting 3000
- add localhost-specific fallback to keep the dev experience intact

## Testing
- pnpm --filter meme-coin-platform-frontend lint *(fails: missing eslint-plugin-react dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68e8b460f7788331b3d50d22c3efca60