### PR TITLE
Update default API endpoint to production host

### DIFF
--- a/frontend/src/config/constants.ts
+++ b/frontend/src/config/constants.ts
@@ -1,5 +1,6 @@
 // API endpoints
-export const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000/api';
+export const API_BASE_URL =
+  import.meta.env.VITE_API_URL || 'http://167.86.85.39:3000/api';
 export const SUI_RPC_URL = import.meta.env.VITE_SUI_RPC_URL || 'https://fullnode.testnet.sui.io';
 
 // Pagination

--- a/frontend/src/services/api/client.ts
+++ b/frontend/src/services/api/client.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 // Create an axios instance with default config
 export const apiClient = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:3000/api',
+  baseURL: import.meta.env.VITE_API_URL || 'http://167.86.85.39:3000/api',
   headers: {
     'Content-Type': 'application/json',
   },

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -22,7 +22,7 @@ const resolveApiBaseUrl = () => {
     return `${protocol}//${hostname}${portSegment}/api`
   }
 
-  return 'http://localhost:3000/api'
+  return 'http://167.86.85.39:3000/api'
 }
 
 const API_URL = resolveApiBaseUrl()


### PR DESCRIPTION
## Summary
- update frontend API configuration fallbacks to use the deployed server at http://167.86.85.39:3000/api

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e8bee644688331a9886aadcfc7f5ab