### PR TITLE
Refactor frontend API base URL configuration

### DIFF
--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -1,0 +1,33 @@
+const DEFAULT_API_PATH = '/api'
+
+const stripTrailingSlash = (url: string) => url.replace(/\/+$/, '')
+
+export const resolveApiBaseUrl = (): string => {
+  const configuredUrl = import.meta.env.VITE_API_URL?.toString().trim()
+  if (configuredUrl) {
+    return stripTrailingSlash(configuredUrl)
+  }
+
+  if (typeof window !== 'undefined') {
+    const { protocol, hostname, port } = window.location
+    const isLocalhost = ['localhost', '127.0.0.1', '::1'].includes(hostname)
+
+    if (isLocalhost) {
+      const devPort = import.meta.env.VITE_API_DEV_PORT?.toString().trim()
+      const effectivePort = devPort || port || '3000'
+      return `${protocol}//${hostname}:${effectivePort}${DEFAULT_API_PATH}`
+    }
+
+    const portSegment = port ? `:${port}` : ''
+    return `${protocol}//${hostname}${portSegment}${DEFAULT_API_PATH}`
+  }
+
+  return DEFAULT_API_PATH
+}
+
+export const API_BASE_URL = resolveApiBaseUrl()
+
+export default {
+  API_BASE_URL,
+  resolveApiBaseUrl,
+}

--- a/frontend/src/config/constants.ts
+++ b/frontend/src/config/constants.ts
@@ -1,6 +1,7 @@
+import { API_BASE_URL } from './api'
+
 // API endpoints
-export const API_BASE_URL =
-  import.meta.env.VITE_API_URL || 'http://167.86.85.39:3000/api';
+export { API_BASE_URL }
 export const SUI_RPC_URL = import.meta.env.VITE_SUI_RPC_URL || 'https://fullnode.testnet.sui.io';
 
 // Pagination

--- a/frontend/src/services/api/client.ts
+++ b/frontend/src/services/api/client.ts
@@ -1,8 +1,9 @@
 import axios from 'axios';
+import { API_BASE_URL } from '../../config/api'
 
 // Create an axios instance with default config
 export const apiClient = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || 'http://167.86.85.39:3000/api',
+  baseURL: API_BASE_URL,
   headers: {
     'Content-Type': 'application/json',
   },

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -1,31 +1,10 @@
 import axios, { AxiosError } from 'axios'
 import { Coin, CoinDetails } from '../types'
 import { Transaction } from '../types'
+import { API_BASE_URL } from '../config/api'
 import { handleApiError, ApiError, NetworkError, TimeoutError } from './errorHandler'
 
-const resolveApiBaseUrl = () => {
-  const configuredUrl = import.meta.env.VITE_API_URL?.toString().trim()
-  if (configuredUrl) {
-    return configuredUrl
-  }
-
-  if (typeof window !== 'undefined') {
-    const { protocol, hostname, port } = window.location
-    const isLocalhost = ['localhost', '127.0.0.1', '::1'].includes(hostname)
-
-    if (isLocalhost) {
-      const devPort = import.meta.env.VITE_API_DEV_PORT || '3000'
-      return `${protocol}//${hostname}:${devPort}/api`
-    }
-
-    const portSegment = port ? `:${port}` : ''
-    return `${protocol}//${hostname}${portSegment}/api`
-  }
-
-  return 'http://167.86.85.39:3000/api'
-}
-
-const API_URL = resolveApiBaseUrl()
+const API_URL = API_BASE_URL
 
 // Create axios instance with base configuration
 const api = axios.create({


### PR DESCRIPTION
## Summary
- centralize API base URL resolution so values come from environment configuration or current host instead of hard-coded IPs
- update frontend API clients and constants to reuse the shared configuration helper

## Testing
- npm run build:frontend

------
https://chatgpt.com/codex/tasks/task_e_68e8c4ea18f08331aa60c57375382fcd