### PR TITLE
refactor: modernize wallet integration

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,10 @@
     "test:e2e": "cypress run"
   },
   "dependencies": {
-    "@mysten/sui.js": "^0.42.0",
+    "@mysten/sui.js": "^0.54.1",
+    "@mysten/wallet-adapter-react": "^0.20.0",
+    "@mysten/wallet-adapter-wallet-standard": "^0.6.0",
+    "@mysten/wallet-standard": "^0.13.0",
     "@reduxjs/toolkit": "^1.9.5",
     "axios": "^1.5.0",
     "react": "^18.2.0",

--- a/frontend/src/config/constants.ts
+++ b/frontend/src/config/constants.ts
@@ -29,10 +29,7 @@ export const CHART_COLORS = {
 
 // Wallet
 export const SUPPORTED_WALLETS = [
-  'Sui Wallet',
-  'Ethos Wallet',
   'Suiet Wallet',
-  'Martian Wallet',
   'Slush Wallet'
 ];
 

--- a/frontend/src/hooks/useWallet.ts
+++ b/frontend/src/hooks/useWallet.ts
@@ -12,6 +12,7 @@ import { suiClient } from '../utils/suiClient'
 import {
   getStoredWalletPreference,
   getWalletAdapter,
+  getWalletAdapterById,
   WALLET_STORAGE_KEY,
   type WalletId
 } from '../utils/walletAdapters'
@@ -31,11 +32,7 @@ export const useWallet = () => {
         throw new Error('Sui wallet not found. Please install a compatible wallet extension.')
       }
 
-      if (adapter.requestPermissions) {
-        await adapter.requestPermissions()
-      } else if (adapter.connect) {
-        await adapter.connect()
-      }
+      await adapter.connect()
 
       const accounts = await adapter.getAccounts()
 
@@ -107,6 +104,12 @@ export const useWallet = () => {
 
   const disconnect = useCallback(() => {
     try {
+      const storedWallet = getStoredWalletPreference()
+      if (storedWallet) {
+        const { adapter } = getWalletAdapterById(storedWallet)
+        void adapter?.disconnect?.()
+      }
+
       localStorage.removeItem('walletConnected')
       localStorage.removeItem(WALLET_STORAGE_KEY)
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,16 +1,44 @@
-import React from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import ReactDOM from 'react-dom/client'
 import { Provider } from 'react-redux'
 import { BrowserRouter } from 'react-router-dom'
+import { WalletProvider } from '@mysten/wallet-adapter-react'
 import App from './App'
 import store from './store'
+import {
+  getWalletProviderAdapters,
+  subscribeToWalletChanges
+} from './utils/walletAdapters'
 import './assets/styles/global.css'
+
+const WalletAdapterManager: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [wallets, setWallets] = useState(() => getWalletProviderAdapters())
+
+  useEffect(() => {
+    const updateWallets = () => {
+      setWallets(getWalletProviderAdapters())
+    }
+
+    const unsubscribe = subscribeToWalletChanges(updateWallets)
+    return () => unsubscribe()
+  }, [])
+
+  const managedWallets = useMemo(() => wallets.slice(), [wallets])
+
+  return (
+    <WalletProvider wallets={managedWallets} autoConnect={false}>
+      {children}
+    </WalletProvider>
+  )
+}
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <Provider store={store}>
       <BrowserRouter>
-        <App />
+        <WalletAdapterManager>
+          <App />
+        </WalletAdapterManager>
       </BrowserRouter>
     </Provider>
   </React.StrictMode>,

--- a/frontend/src/pages/FAQ.tsx
+++ b/frontend/src/pages/FAQ.tsx
@@ -50,8 +50,7 @@ const FAQ: React.FC = () => {
     },
     {
       question: 'What wallets are supported?',
-      answer:
-        'We currently support Sui Wallet, Ethos Wallet, Suiet Wallet, Martian Wallet, and Slush Wallet. More wallet integrations are planned for the future.',
+      answer: 'We currently support Suiet Wallet and Slush Wallet via the latest Sui wallet standard. More wallet integrations are planned for the future.',
       category: 'wallets'
     },
     {

--- a/frontend/src/utils/suiClient.ts
+++ b/frontend/src/utils/suiClient.ts
@@ -41,9 +41,7 @@ export const connectWallet = async (walletId?: WalletId) => {
   try {
     const wallet = getActiveWallet(walletId)
 
-    if (wallet.requestPermissions) {
-      await wallet.requestPermissions()
-    }
+    await wallet.connect()
 
     const accounts = await wallet.getAccounts()
 


### PR DESCRIPTION
## Summary
- update the front-end wallet dependencies to the latest Mysten wallet adapter packages
- refactor wallet utilities and bootstrap to use the wallet standard provider and expose only Suiet and Slush wallets
- refresh wallet connection UI copy and FAQs to match the new supported wallets

## Testing
- npm run lint:frontend *(fails: eslint-plugin-react is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e8f1c8adac8331b0c3a06acc5ed091