### PR TITLE
fix: remove unused mysten wallet adapter dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "@mysten/sui.js": "^0.54.1",
-    "@mysten/wallet-adapter-react": "^0.20.0",
     "@mysten/wallet-adapter-wallet-standard": "^0.6.0",
     "@mysten/wallet-standard": "^0.13.0",
     "@reduxjs/toolkit": "^1.9.5",

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,44 +1,16 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { Provider } from 'react-redux'
 import { BrowserRouter } from 'react-router-dom'
-import { WalletProvider } from '@mysten/wallet-adapter-react'
 import App from './App'
 import store from './store'
-import {
-  getWalletProviderAdapters,
-  subscribeToWalletChanges
-} from './utils/walletAdapters'
 import './assets/styles/global.css'
-
-const WalletAdapterManager: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [wallets, setWallets] = useState(() => getWalletProviderAdapters())
-
-  useEffect(() => {
-    const updateWallets = () => {
-      setWallets(getWalletProviderAdapters())
-    }
-
-    const unsubscribe = subscribeToWalletChanges(updateWallets)
-    return () => unsubscribe()
-  }, [])
-
-  const managedWallets = useMemo(() => wallets.slice(), [wallets])
-
-  return (
-    <WalletProvider wallets={managedWallets} autoConnect={false}>
-      {children}
-    </WalletProvider>
-  )
-}
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <Provider store={store}>
       <BrowserRouter>
-        <WalletAdapterManager>
-          <App />
-        </WalletAdapterManager>
+        <App />
       </BrowserRouter>
     </Provider>
   </React.StrictMode>,


### PR DESCRIPTION
## Summary
- remove the unused WalletProvider wrapper from the React entrypoint
- drop the @mysten/wallet-adapter-react dependency from the frontend workspace

## Testing
- npm run lint:frontend *(fails: missing eslint-plugin-react in the repo setup)*

------
https://chatgpt.com/codex/tasks/task_e_68e93aee1ed0833199c61b3bd36cc37d